### PR TITLE
Ensure the correct Rust version when running locally and on CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: generic
 
 install:
-  - ci/install.sh
+  - scripts/install.sh
 
 script:
-  - ci/test.sh
+  - scripts/test.sh
 
 deploy:
   provider: script
-  script: ci/deploy.sh
+  script: scripts/deploy.sh
   skip_cleanup: true
   on:
     tags: true

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -3,9 +3,9 @@
 
 This talks about how to run this project locally and how to make changes to it.
  
-You can just run `./ci/install.sh` to get all dependencies going. This will install Rust and Node via NVM - please review the script before running, to see if this is what you want on your machine.
+You can just run `./scripts/install.sh` to get all dependencies going. This will install Rust and Node via NVM - please review the script before running, to see if this is what you want on your machine.
 
-To make sure everything is working run `./ci/test.sh` - this will launch all the Rust tests and then package npm package and run node tests on it.
+To make sure everything is working run `./scripts/test.sh` - this will launch all the Rust tests and then package npm package and run node tests on it.
 
 ## Tests
 

--- a/fuzz/run-fuzzer.sh
+++ b/fuzz/run-fuzzer.sh
@@ -2,14 +2,14 @@
 set -e
 set -o pipefail
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-PARENT="$HERE/../"
+PARENT="${HERE}/../"
 
 (test -x "${HOME}/.cargo/bin/cargo-fuzz" || cargo install cargo-fuzz)
 
 # it is important for `cargo fuzz` to be run from the project root
-cd "$PARENT"
+cd "${PARENT}"
 
-mkdir -p "$HERE/corpus"
+mkdir -p "${HERE}/corpus"
 rustup override set nightly
 # run `any_input` target using `seeds` as a start point and put new corpus state into `corpus`
-cargo fuzz run generator "$HERE/corpus" "$HERE/seeds" -j 6 --all-features
+cargo fuzz run generator "${HERE}/corpus" "${HERE}/seeds" -j 6 --all-features

--- a/node/tests/README.md
+++ b/node/tests/README.md
@@ -6,6 +6,6 @@ We do not need to test actual functionality as it is tested in the Rust code.
 
 ## Run tests
 
-* Build isomorphic NPM package with `ci/build-wasm.sh` script
+* Build isomorphic NPM package with `scripts/build-wasm.sh` script
 * Install dependencies with `npm install`
 * Run tests with `npm test`

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -13,6 +13,9 @@ source "${HOME}/.nvm/nvm.sh"
 nvm use
 source "${HOME}/.cargo/env"
 
+echo "Setting rustup override for this project"
+rustup override set `cat rust-toolchain`
+
 TARGET_DIR="target/npm"
 # Browser specific NPM package
 BROWSER_PKG_DIR="${TARGET_DIR}/pkg-browser"

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -14,7 +14,7 @@ nvm use
 source "${HOME}/.cargo/env"
 
 echo "Setting rustup override for this project"
-rustup override set `cat rust-toolchain`
+rustup override set $(cat rust-toolchain)
 
 TARGET_DIR="target/npm"
 # Browser specific NPM package

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,9 +2,14 @@
 
 set -e
 
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
 source "${HOME}/.cargo/env"
 source "${HOME}/.nvm/nvm.sh"
 nvm use
+
+echo "Setting rustup override for this project"
+rustup override set `cat rust-toolchain`
 
 echo "Authenticating to crates.io..."
 cargo login "${CARGO_API_TOKEN}"
@@ -14,7 +19,7 @@ cargo publish
 echo "Authenticating to npmjs.org registry..."
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
-ci/build-wasm.sh
+$HERE/build-wasm.sh
 
 echo "Publishing NPM package..."
 npm publish --access public target/npm/pkg

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,7 +19,7 @@ cargo publish
 echo "Authenticating to npmjs.org registry..."
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
-"$HERE/build-wasm.sh"
+"${HERE}/build-wasm.sh"
 
 echo "Publishing NPM package..."
 npm publish --access public target/npm/pkg

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,7 +9,7 @@ source "${HOME}/.nvm/nvm.sh"
 nvm use
 
 echo "Setting rustup override for this project"
-rustup override set `cat rust-toolchain`
+rustup override set $(cat rust-toolchain)
 
 echo "Authenticating to crates.io..."
 cargo login "${CARGO_API_TOKEN}"
@@ -19,7 +19,7 @@ cargo publish
 echo "Authenticating to npmjs.org registry..."
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
-$HERE/build-wasm.sh
+"$HERE/build-wasm.sh"
 
 echo "Publishing NPM package..."
 npm publish --access public target/npm/pkg

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 RUSTUP_COMMAND="curl https://sh.rustup.rs -sSf | sh -s -- -y"
-if [ ! -z $CI ]; then
+if [ ! -z "${CI}" ]; then
     default_compiler=`cat rust-toolchain`
     echo "Setting the default compiler to ${default_compiler}"
     RUSTUP_COMMAND="$RUSTUP_COMMAND --default-toolchain ${default_compiler}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,8 +3,15 @@
 set -e
 set -o pipefail
 
+rustup_commandline="curl https://sh.rustup.rs -sSf | sh -s -- -y"
+if [ ! -z $CI ]; then
+    default_compiler=`cat rust-toolchain`
+    echo "Setting the default compiler to $default_compiler"
+    rustup_commandline="$rustup_commandline --default-toolchain $default_compiler"
+fi
 echo "Installing Rust toolchain..."
-curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $(cat rust-toolchain)
+eval $rustup_commandline
+
 source "${HOME}/.cargo/env"
 rustup component add clippy
 rustup component add rustfmt

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,11 +6,11 @@ set -o pipefail
 RUSTUP_COMMAND="curl https://sh.rustup.rs -sSf | sh -s -- -y"
 if [ ! -z $CI ]; then
     default_compiler=`cat rust-toolchain`
-    echo "Setting the default compiler to $default_compiler"
-    RUSTUP_COMMAND="$RUSTUP_COMMAND --default-toolchain $default_compiler"
+    echo "Setting the default compiler to ${default_compiler}"
+    RUSTUP_COMMAND="$RUSTUP_COMMAND --default-toolchain ${default_compiler}"
 fi
 echo "Installing Rust toolchain..."
-eval $RUSTUP_COMMAND
+eval "${RUSTUP_COMMAND}"
 
 source "${HOME}/.cargo/env"
 rustup component add clippy

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,14 +3,14 @@
 set -e
 set -o pipefail
 
-rustup_commandline="curl https://sh.rustup.rs -sSf | sh -s -- -y"
+RUSTUP_COMMAND="curl https://sh.rustup.rs -sSf | sh -s -- -y"
 if [ ! -z $CI ]; then
     default_compiler=`cat rust-toolchain`
     echo "Setting the default compiler to $default_compiler"
-    rustup_commandline="$rustup_commandline --default-toolchain $default_compiler"
+    RUSTUP_COMMAND="$RUSTUP_COMMAND --default-toolchain $default_compiler"
 fi
 echo "Installing Rust toolchain..."
-eval $rustup_commandline
+eval $RUSTUP_COMMAND
 
 source "${HOME}/.cargo/env"
 rustup component add clippy

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,9 +5,9 @@ set -o pipefail
 
 RUSTUP_COMMAND="curl https://sh.rustup.rs -sSf | sh -s -- -y"
 if [ ! -z "${CI}" ]; then
-    default_compiler=`cat rust-toolchain`
-    echo "Setting the default compiler to ${default_compiler}"
-    RUSTUP_COMMAND="$RUSTUP_COMMAND --default-toolchain ${default_compiler}"
+    DEFAULT_COMPILER=`cat rust-toolchain`
+    echo "Setting the default compiler to ${DEFAULT_COMPILER}"
+    RUSTUP_COMMAND="$RUSTUP_COMMAND --default-toolchain ${DEFAULT_COMPILER}"
 fi
 echo "Installing Rust toolchain..."
 eval "${RUSTUP_COMMAND}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,7 +10,7 @@ nvm use
 source "${HOME}/.cargo/env"
 
 echo "Setting rustup override for this project"
-rustup override set `cat rust-toolchain`
+rustup override set $(cat rust-toolchain)
 
 TESTS_DIRECTORY=tests
 
@@ -39,7 +39,7 @@ if [ -z "$CI" ]; then
 fi
 cargo package ${CARGO_PACKAGE_ARGS}
 
-$HERE/build-wasm.sh
+"$HERE/build-wasm.sh"
 
 echo "Testing browser NPM package..."
 wasm-pack test --chrome --firefox --headless

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,10 +15,10 @@ rustup override set $(cat rust-toolchain)
 TESTS_DIRECTORY=tests
 
 echo "Linting yaml schemas"
-find "$TESTS_DIRECTORY" -iname *.yaml -not -path "*/fuzzer/*" -exec yamllint {} +
+find "${TESTS_DIRECTORY}" -iname *.yaml -not -path "*/fuzzer/*" -exec yamllint {} +
 
 echo "Linting JSONSchemas"
-find "$TESTS_DIRECTORY" -type f -iname "output-json-schema.json" -print0 | while IFS= read -r -d $'\0' file; do
+find "${TESTS_DIRECTORY}" -type f -iname "output-json-schema.json" -print0 | while IFS= read -r -d $'\0' file; do
     ajv compile -s "$file" --format='false'
 done
 
@@ -33,13 +33,13 @@ cargo test
 
 echo "Trying to package Rust crate..."
 CARGO_PACKAGE_ARGS=''
-if [ -z "$CI" ]; then
+if [ -z "${CI}" ]; then
     # Allow to test uncommitted changes locally
     CARGO_PACKAGE_ARGS='--allow-dirty'
 fi
 cargo package ${CARGO_PACKAGE_ARGS}
 
-"$HERE/build-wasm.sh"
+"${HERE}/build-wasm.sh"
 
 echo "Testing browser NPM package..."
 wasm-pack test --chrome --firefox --headless

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,4 @@
+#[allow(clippy:all)]
 // generated via `build.rs`, one test per directory in tests/data
 include!(concat!(env!("OUT_DIR"), "/validator_data_tests.rs"));
 include!(concat!(env!("OUT_DIR"), "/validator_errors_tests.rs"));


### PR DESCRIPTION
* As we encourage the scripts to be runnable locally as well as on CI -
renamed the `ci` directory to `scripts`
* Install script should be safer to run locally now - it only sets the
default global compiler version on CI
* Each script sets its own rustup override so that we make sure the
build and tests are run with the correct Rust version
